### PR TITLE
add options, export cmake config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,25 +1,48 @@
 cmake_minimum_required(VERSION 3.10)
 project(crossdb)
 add_compile_options(-O2)
+
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
+option(ENABLE_CLI "Build CLI executable" ON)
+option(ENABLE_PACKAGE "Build package" ON)
+
 add_library(crossdb src/crossdb.c)
-add_executable(xdb-cli src/xdb-cli.c)
 IF (CMAKE_SYSTEM_NAME MATCHES "Windows")
-target_link_libraries(xdb-cli pthread ws2_32 regex)
-target_link_libraries(crossdb pthread ws2_32 regex)
-ELSE ()
-target_link_libraries(xdb-cli pthread dl)
+    target_link_libraries(crossdb pthread ws2_32 regex)
 ENDIF ()
 set_target_properties(crossdb PROPERTIES PUBLIC_HEADER "include/crossdb.h")
 
 #add_subdirectory(jni)
+include(GNUInstallDirs)
+INSTALL(
+	TARGETS crossdb
+    EXPORT crossdb-export
+	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+	PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
 
 INSTALL(
-	TARGETS xdb-cli crossdb
-	RUNTIME DESTINATION bin
-	LIBRARY DESTINATION lib
-	PUBLIC_HEADER DESTINATION include
+    EXPORT crossdb-export
+    FILE crossdb-config.cmake
+    NAMESPACE crossdb::
+    DESTINATION lib/cmake/crossdb
 )
+
+if(ENABLE_CLI)
+    add_executable(xdb-cli src/xdb-cli.c)
+    IF (CMAKE_SYSTEM_NAME MATCHES "Windows")
+        target_link_libraries(xdb-cli pthread ws2_32 regex)
+    ELSE ()
+        target_link_libraries(xdb-cli pthread dl)
+    ENDIF ()
+    INSTALL(
+	    TARGETS xdb-cli
+    	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
+endif()
 
 add_custom_target("uninstall" COMMENT "Uninstall installed files")
 add_custom_command(
@@ -30,15 +53,17 @@ add_custom_command(
             install_manifest.txt to be uninstalled!
 )
 
-set(CPACK_PACKAGE_NAME crossdb)
-set(CPACK_PACKAGE_VERSION_MAJOR 0)
-set(CPACK_PACKAGE_VERSION_MINOR 14)
-set(CPACK_PACKAGE_VERSION_PATCH 0)
-set(CPACK_PACKAGE_CONTACT "crossdb <support@crossdb.org>")
-#set(CPACK_GENERATOR DEB NSIS RPM)
-IF (CMAKE_SYSTEM_NAME MATCHES "Linux")
-set(CPACK_GENERATOR DEB ZIP)
-ELSE ()
-set(CPACK_GENERATOR ZIP)
-ENDIF ()
-include(CPack)
+if(ENABLE_PACKAGE)
+    set(CPACK_PACKAGE_NAME crossdb)
+    set(CPACK_PACKAGE_VERSION_MAJOR 0)
+    set(CPACK_PACKAGE_VERSION_MINOR 14)
+    set(CPACK_PACKAGE_VERSION_PATCH 0)
+    set(CPACK_PACKAGE_CONTACT "crossdb <support@crossdb.org>")
+    #set(CPACK_GENERATOR DEB NSIS RPM)
+    IF (CMAKE_SYSTEM_NAME MATCHES "Linux")
+        set(CPACK_GENERATOR DEB ZIP)
+    ELSE ()
+        set(CPACK_GENERATOR ZIP)
+    ENDIF ()
+    include(CPack)
+endif()


### PR DESCRIPTION
I would like to add the following modifications to create vcpkg port.

- add options to control xdb-cli compiling and packaging
- install cmake config file to be used in find_package()

Please point out any problems with the style of CMakeLists.txt. I have no particular preference for style.